### PR TITLE
Remove error 9020 from getInitializationContextAsync call

### DIFF
--- a/taskpane/taskpane.js
+++ b/taskpane/taskpane.js
@@ -38,14 +38,8 @@ function loadNewMessage(eventArgs) {
           $("#no-context").show();
         }
       } else {
-        // Today OWA returns an error instead of empty string
-        // when there is no context
-        if (asyncResult.error.code == 9020) {
-          $("#no-context").show();
-        } else {
           // Show the error
           showError(JSON.stringify(asyncResult.error, null, 2));
-        }
       }
 
       // Register for InitializationContextChanged


### PR DESCRIPTION
Updates the getInitializationContextAsync snippet as the 9020 error is no longer returned when there is no initialization context. Related change: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63441.

Other related PRs: https://github.com/OfficeDev/outlook-dev-docs/pull/979 